### PR TITLE
Use wslview when running in WSL

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import { resolve, normalize, join, relative } from 'https://deno.land/std@0.106.0/path/posix.ts';
+import { isWsl } from 'https://deno.land/x/is_wsl@v1.1.0/mod.ts';
 const { os } = Deno.build;
 
 /**
@@ -117,8 +118,11 @@ export async function open(target: string, options?: OpenOptions): Promise<Deno.
       cliArguments.push(...appArguments);
     }
   } else {
+    let wsl = await isWsl();
     if (options.app) {
       command = options.app;
+    } else if (wsl) {
+      command = 'wslview';
     } else {
       // When bundled by Webpack, there's no actual package file path and no local `xdg-open`.
       const isBundled = !getDir(import.meta.url) || getDir(import.meta.url) === '/';


### PR DESCRIPTION
Hello and thank you for writing `deno-open`! This is a small PR to make `deno-open` work as expected when running under the Windows Subsystem for Linux (WSL).

In a nutshell, `xdg-open` doesn't exist on WSL and the preferred launcher is usually [`wslview`](https://manpages.ubuntu.com/manpages/impish/man1/wslview.1.html).

The `open-rs` Rust crate does a WSL check very much like this: https://github.com/Byron/open-rs/blob/b076fc44a984b55b0ca986530e9f4a18f1a43ba4/src/unix.rs#L12-L15