### PR TITLE
make note for windows more clear in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > open is a package for opening URLs, files and executables. Inspired by [open](https://github.com/sindresorhus/open)
 
+> ⚠ Note: on Windows, if you have search parameters in your URL, you need need to wrap the `&` char in quote marks. See [#9](https://github.com/skoshx/deno-open/issues/9) ⚠
+
 ## Features
 
 - Really simple usage
@@ -59,5 +61,3 @@ Specify the app you want to open the target with.
 #### url: `boolean`
 
 Encodes target with `encodeURI`. Useful for opening URLs.
-
-> Note: on Windows, if you have search parameters in your URL, you need need to wrap the `&` char in quote marks. See [#9](https://github.com/skoshx/deno-open/issues/9)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 > open is a package for opening URLs, files and executables. Inspired by [open](https://github.com/sindresorhus/open)
 
-> ⚠ Note: on Windows, if you have search parameters in your URL, you need need to wrap the `&` char in quote marks. See [#9](https://github.com/skoshx/deno-open/issues/9) ⚠
-
 ## Features
 
 - Really simple usage
@@ -31,6 +29,8 @@ await open('https://google.com', {app: 'firefox'});
 // Specify app arguments.
 await open('https://google.com', {app: ['google chrome', '--incognito']});
 ```
+
+> ⚠ Note: on Windows, if you have search parameters in your URL, you need need to wrap the `&` char in quote marks. See [#9](https://github.com/skoshx/deno-open/issues/9) ⚠
 
 ## API
 
@@ -61,3 +61,5 @@ Specify the app you want to open the target with.
 #### url: `boolean`
 
 Encodes target with `encodeURI`. Useful for opening URLs.
+
+> Note: on Windows, if you have search parameters in your URL, you need need to wrap the `&` char in quote marks. See [#9](https://github.com/skoshx/deno-open/issues/9)


### PR DESCRIPTION
I didn't notice the note for windows at the bottom of the readme, I feel as if it would be more useful if it were more obvious. The note has been moved to the top and wrapped in warning emojis